### PR TITLE
Add Ruby on Rails Tutorial to books

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ https://www.youtube.com/user/Confreaks
 
 http://apionrails.icalialabs.com/book/chapter_one
 
+### Ruby on Rails Tutorial by Michael Hartl
+
+https://www.railstutorial.org/book
+
 ---
 
 ## Articles


### PR DESCRIPTION
Doesn't seem right to have a list of rails resources that doesn't include the book that got me started :)
